### PR TITLE
docs: bringing back getDownloadUrl on AttachmentCardView since google inbox is gone

### DIFF
--- a/docs/conversations.md
+++ b/docs/conversations.md
@@ -315,7 +315,7 @@ Reads the title on the attachment card. Typically this will be a filename.
 _Returns_ a `string`
 
 #### getDownloadURL()
-This method is deprecated. Please use the same-named method on the AttachmentCardClickEvent object instead.
+Get the URL for the attachment card's download link as a promise for a string. For FILE attachment cards, the URL will be a short-lived URL that can be accessed without cookies. For CUSTOM attachment cards, the URL will be the downloadUrl property of the card's download button if it has one, otherwise null. Other attachment card types may not have a download URL, and the promise may resolve to null.
 
 _Returns_ a `Promise<string>`
 


### PR DESCRIPTION
getDownloadURL was removed from AttachmentCardView here: https://github.com/InboxSDK/InboxSDK/commit/c43493ebc71ce86f303ad14e990dc880ea9a4fda

but this was done for google inbox, which isn't present now, so we discussed this if we could bring it back, discussion link: https://github.com/InboxSDK/InboxSDK/issues/794#issuecomment-1279060304

InboxSDK PR: https://github.com/InboxSDK/InboxSDK/pull/1180