### PR TITLE
update docs for createShortcutHandle and showModalView

### DIFF
--- a/docs/keyboard-shortcuts.md
+++ b/docs/keyboard-shortcuts.md
@@ -33,3 +33,4 @@ Describes a keyboard shortcut combination
 | :--- | :--- | :--- | :--- | :--- |
 | **chord** | `string` | The keys the user has to press to activate the shortcut. Simultaneous keypresses can be defined with "+". For multi-key chords like Gmail's, include a space between the keys, i.e. "g i". Syntax matches the combokeys library. | Yes |  |
 | **description** | `string` | The description text that shows up in Gmail's keyboard shortcut help (when the user presses '?'). | Yes |  |
+| **orderHint** | `integer` | Used to sort the shortcuts in the Gmail keyboard shortcut help (ascending). Shortcuts without orderHint will be shown at the end. | No | undefined |

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -47,6 +47,7 @@ The options used to configure a modal when calling Widgets.showModalView().
 | **showCloseButton** | `boolean` | When chrome is set to false, this option controls whether a close (X) button should be added to the modal anyway. If chrome is set to true then this property doesn't do anything. | No | `false` |
 | **title** | `string` | Text to show as the title of the modal | No | `''` |
 | **buttons** | `Array<ModalButtonDescriptor>` | An array of buttons to add to the modal. The UI will be consistent with native Gmail buttons. If none are provided, your el will occupy all of the modal. There may only be one button with a type of PRIMARY_ACTION, see ModalButtonDescriptor docs | No | `[]` |
+| **closeOnEscape** | `boolean` | Wether the modal should close when the user hits the `escape` key. | No | `true` |
 
 
 


### PR DESCRIPTION
We recently added option for 

- `createShortcutHandle`: `orderHint` (optional) allows to set the order of keyboard shortcuts in Gmail's keyboard shortcut help. 
- `showModalView`: `closeOnEscape` (optional) allows to prevent closing the modal when the user hits <kbd>escape</kbd>. 

In both cases the options are optional and default to the current behaviour (backwards compatible).